### PR TITLE
Fix for incorrect github.action_path in containers

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,12 +31,12 @@ outputs:
 runs:
   using: composite
   steps:
-    - run: ${{ github.action_path }}/bin/ensure_python
+    - run: $GITHUB_ACTION_PATH/bin/ensure_python
       shell: bash
     - run:
-        ${{ github.action_path }}/bin/install_packages ${{ inputs.prefect-version }} ${{ inputs.requirements-files }}
+        $GITHUB_ACTION_PATH/bin/install_packages ${{ inputs.prefect-version }} ${{ inputs.requirements-files }}
       shell: bash
     - id: run-prefect-command
       run:
-        ${{ github.action_path }}/bin/run_prefect ${{ inputs.command }}
+        $GITHUB_ACTION_PATH/bin/run_prefect ${{ inputs.command }}
       shell: bash


### PR DESCRIPTION
I had the same problem that's posted here: https://github.com/zbazztian/filter-sarif/pull/4#issue-1280122937. To quote them: 
"When run in a container, the github.action_path doesn't point to the right place. The GITHUB_ACTION_PATH env var does." 
I'm not sure if there's a better solution, but this worked for me! 